### PR TITLE
fix(linux): warn when debug symbols are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ cargo test --test integration_tests -- --include-ignored
 
 ---
 
+## Known Limitations
+
+- On Linux, stack trace function names require DWARF debug info. If the target binary is stripped or built without `-g`, `mvis leak` falls back to module offsets such as `libc.so+0x2a3f1` and prints a warning.
+
+---
+
 ### Roadmap
 - [x] TUI frontend for heap analysis (Changed to TUI instead of GUI following our design philosophy of being lightweight)
 - [ ] Heap fragmentation visualization

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -438,6 +438,9 @@ pub fn leak_command(pid: u32, interval: u64) {
 
             if let Ok(t) = trace {
                 println!("\ncall stack at time of snapshot:");
+                if let Some(warning) = &t.symbol_warning {
+                    println!("warning: {}", warning);
+                }
                 for (i, frame) in t.frames.iter().enumerate() {
                     println!("  #{:<2} {}", i, frame.symbol);
                 }
@@ -506,6 +509,12 @@ pub fn leak_command_tui(pid: u32, interval: u64) -> Vec<Line<'static>> {
                     "call stack at time of snapshot:",
                     Style::default().fg(Color::Cyan),
                 )));
+                if let Some(warning) = &t.symbol_warning {
+                    output.push(Line::from(Span::styled(
+                        format!("warning: {}", warning),
+                        Style::default().fg(Color::Yellow),
+                    )));
+                }
                 for (i, frame) in t.frames.iter().enumerate() {
                     output.push(Line::raw(format!("  #{:<2} {}", i, frame.symbol)));
                 }

--- a/src/stack_trace.rs
+++ b/src/stack_trace.rs
@@ -21,6 +21,14 @@
 
 use serde::Serialize;
 
+pub const MISSING_DEBUG_INFO_WARNING: &str =
+    "Some binaries are stripped. Recompile with -g to see function names.";
+
+#[cfg(any(target_os = "linux", test))]
+fn symbol_warning(missing_debug_info: bool) -> Option<String> {
+    missing_debug_info.then(|| MISSING_DEBUG_INFO_WARNING.to_string())
+}
+
 #[derive(Clone, Debug, Serialize)]
 pub struct StackFrame {
     pub instruction_pointer: usize,
@@ -34,6 +42,7 @@ pub struct StackFrame {
 pub struct StackTrace {
     pub pid: u32,
     pub frames: Vec<StackFrame>,
+    pub symbol_warning: Option<String>,
 }
 
 // ── platform dispatch ────────────────────────────────────────────────────────
@@ -72,7 +81,7 @@ pub fn resolve(ip: usize, regions: &[crate::types::Region]) -> String {
 
 #[cfg(target_os = "linux")]
 mod linux {
-    use super::{StackFrame, StackTrace};
+    use super::{StackFrame, StackTrace, symbol_warning};
     use nix::sys::ptrace;
     use nix::sys::wait::{WaitStatus, waitpid};
     use nix::unistd::Pid;
@@ -87,7 +96,7 @@ mod linux {
         }
 
         let regs = ptrace::getregs(nix_pid).map_err(|e| format!("getregs: {e}"))?;
-        let frames = unwind(
+        let (frames, missing_debug_info) = unwind(
             nix_pid,
             regs.rip as usize,
             regs.rsp as usize,
@@ -96,7 +105,11 @@ mod linux {
         );
 
         ptrace::detach(nix_pid, None).map_err(|e| format!("ptrace detach: {e}"))?;
-        Ok(StackTrace { pid, frames })
+        Ok(StackTrace {
+            pid,
+            frames,
+            symbol_warning: symbol_warning(missing_debug_info),
+        })
     }
 
     fn peek(pid: Pid, addr: usize) -> Option<usize> {
@@ -133,7 +146,28 @@ mod linux {
         0
     }
 
-    fn resolve_sym(ip: usize, pid: Pid, regions: &[crate::types::Region]) -> String {
+    struct ResolvedSymbol {
+        symbol: String,
+        missing_debug_info: bool,
+    }
+
+    impl ResolvedSymbol {
+        fn ok(symbol: String) -> Self {
+            Self {
+                symbol,
+                missing_debug_info: false,
+            }
+        }
+
+        fn missing_debug_info(symbol: String) -> Self {
+            Self {
+                symbol,
+                missing_debug_info: true,
+            }
+        }
+    }
+
+    fn resolve_sym(ip: usize, pid: Pid, regions: &[crate::types::Region]) -> ResolvedSymbol {
         use object::{Object, ObjectSection};
 
         let region = regions
@@ -141,21 +175,26 @@ mod linux {
             .find(|r| ip >= r.base && ip < r.base + r.size);
         let (path, map_base) = match region {
             Some(r) if !r.name.is_empty() => (r.name.clone(), r.base),
-            _ => return format!("0x{:x}", ip),
+            _ => return ResolvedSymbol::ok(format!("0x{:x}", ip)),
         };
+        let fallback = || format!("{}+0x{:x}", path, ip - map_base);
 
         let file = match std::fs::File::open(&path) {
             Ok(f) => f,
-            Err(_) => return format!("{}+0x{:x}", path, ip - map_base),
+            Err(_) => return ResolvedSymbol::ok(fallback()),
         };
         let mmap = match unsafe { memmap2::Mmap::map(&file) } {
             Ok(m) => m,
-            Err(_) => return format!("{}+0x{:x}", path, ip - map_base),
+            Err(_) => return ResolvedSymbol::ok(fallback()),
         };
         let obj = match object::File::parse(&*mmap) {
             Ok(o) => o,
-            Err(_) => return format!("{}+0x{:x}", path, ip - map_base),
+            Err(_) => return ResolvedSymbol::ok(fallback()),
         };
+
+        if obj.section_by_name(".debug_info").is_none() {
+            return ResolvedSymbol::missing_debug_info(fallback());
+        }
 
         // find the ELF's own preferred load address from the first LOAD segment
         let elf_load_base: u64 = obj
@@ -199,12 +238,12 @@ mod linux {
 
         let dwarf = match gimli::Dwarf::load(load) {
             Ok(d) => d,
-            Err(_) => return format!("{}+0x{:x}", path, ip - map_base),
+            Err(_) => return ResolvedSymbol::ok(fallback()),
         };
 
         let ctx = match addr2line::Context::from_dwarf(dwarf) {
             Ok(c) => c,
-            Err(_) => return format!("{}+0x{:x}", path, ip - map_base),
+            Err(_) => return ResolvedSymbol::ok(fallback()),
         };
 
         match ctx.find_frames(file_va).skip_all_loads() {
@@ -215,17 +254,17 @@ mod linux {
                         .as_ref()
                         .and_then(|f| f.demangle().ok())
                         .map(|s| s.to_string())
-                        .unwrap_or_else(|| format!("{}+0x{:x}", path, ip - map_base));
+                        .unwrap_or_else(&fallback);
                     let loc = frame
                         .location
                         .as_ref()
                         .map(|l| format!("  {}:{}", l.file.unwrap_or("?"), l.line.unwrap_or(0)))
                         .unwrap_or_default();
-                    return format!("{}{}", func, loc);
+                    return ResolvedSymbol::ok(format!("{}{}", func, loc));
                 }
-                format!("{}+0x{:x}", path, ip - map_base)
+                ResolvedSymbol::ok(fallback())
             }
-            Err(_) => format!("{}+0x{:x}", path, ip - map_base),
+            Err(_) => ResolvedSymbol::ok(fallback()),
         }
     }
 
@@ -235,8 +274,9 @@ mod linux {
         mut rsp: usize,
         mut rbp: usize,
         regions: &[crate::types::Region],
-    ) -> Vec<StackFrame> {
+    ) -> (Vec<StackFrame>, bool) {
         let mut frames = Vec::new();
+        let mut missing_debug_info = false;
 
         for _ in 0..128 {
             if rbp == 0 || rbp < rsp {
@@ -244,13 +284,14 @@ mod linux {
             }
 
             let return_address = peek(pid, rbp + 8).unwrap_or(0);
-            let symbol = resolve_sym(rip, pid, regions);
+            let resolved = resolve_sym(rip, pid, regions);
+            missing_debug_info |= resolved.missing_debug_info;
 
             frames.push(StackFrame {
                 instruction_pointer: rip,
                 base_pointer: rbp,
                 return_address,
-                symbol,
+                symbol: resolved.symbol,
             });
 
             if return_address == 0 {
@@ -261,7 +302,7 @@ mod linux {
             rsp = rbp + 16;
             rbp = prev_rbp;
         }
-        frames
+        (frames, missing_debug_info)
     }
 }
 
@@ -396,6 +437,7 @@ mod windows {
             Ok(StackTrace {
                 pid,
                 frames: all_frames,
+                symbol_warning: None,
             })
         }
     }
@@ -423,5 +465,19 @@ mod windows {
             }
         }
         threads
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MISSING_DEBUG_INFO_WARNING, symbol_warning};
+
+    #[test]
+    fn symbol_warning_describes_missing_linux_debug_info() {
+        assert_eq!(
+            symbol_warning(true).as_deref(),
+            Some(MISSING_DEBUG_INFO_WARNING)
+        );
+        assert!(symbol_warning(false).is_none());
     }
 }


### PR DESCRIPTION
## Description
Detects Linux stack frames that resolve to ELF objects without `.debug_info` and carries a warning through `StackTrace`. The leak output now shows that warning in both CLI and TUI output, and the README documents the Linux debug-symbol limitation.

Fixes #5

## Type of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [x] **Documentation update**
- [ ] **Chore / Refactor**

## Related issues
- **Issue:** #5
- **Related PRs:** none

## How Has This Been Tested
- **Unit tests:** `cargo test`
- **Integration tests:** covered by `cargo test`
- **Manual steps:** `cargo fmt --check`; `cargo build --release`; `cargo check --target x86_64-unknown-linux-gnu`
- **Platform tested on:** Windows local build/test, Linux target compile check

## Checklist
- [x] **I have read the CONTRIBUTING.md** and followed the repo guidelines.
- [x] **Code builds locally** (`cargo build --release`)
- [x] **All tests pass** (`cargo test`)
- [x] **New and existing tests cover my changes**
- [x] **I added/updated documentation** where applicable
- [ ] **I updated CHANGELOG or release notes** if needed

## CI and Performance Notes
- **CI status:** expected to pass.
- **Performance impact:** negligible; Linux symbol resolution now checks for `.debug_info` before attempting DWARF resolution.

## Screenshots or Logs
N/A

## Release Notes
- **Release type:** patch
- **Notes for release manager:** Linux leak stack traces now warn when stripped binaries prevent function-name resolution.