### PR TITLE
Refactor: standardize memory byte formatting across the codebase

### DIFF
--- a/src/utils/formatting.rs
+++ b/src/utils/formatting.rs
@@ -1,0 +1,22 @@
+// src/utils/formatting.rs
+
+const KB: f64 = 1024.0;
+const MB: f64 = KB * 1024.0;
+const GB: f64 = MB * 1024.0;
+const TB: f64 = GB * 1024.0;
+
+pub fn format_bytes(size: u64) -> String {
+    let size_f = size as f64;
+
+    if size_f >= TB {
+        format!("{:.2} TB", size_f / TB)
+    } else if size_f >= GB {
+        format!("{:.2} GB", size_f / GB)
+    } else if size_f >= MB {
+        format!("{:.2} MB", size_f / MB)
+    } else if size_f >= KB {
+        format!("{:.2} KB", size_f / KB)
+    } else {
+        format!("{} B", size)
+    }
+}


### PR DESCRIPTION
fixes #34

I created a centralized utility module at {src/utils/formatting.rs}. It includes a {format_bytes(size: u64) -> String} function that automatically scales the size to the appropriate base-2 unit (B, KB, MB, GB, TB) and formats it consistently to two decimal places.