### PR TITLE
refactor: replaced manual byte formatting with format_bytes utility

### DIFF
--- a/src/core/delta.rs
+++ b/src/core/delta.rs
@@ -1,3 +1,5 @@
+use crate::utils::formatting::format_bytes;
+
 #[derive(Debug, Clone)]
 pub struct LeakDelta {
     pub freed_bytes: usize,
@@ -14,14 +16,14 @@ impl LeakDelta {
     /// Generates the single line of truth requested for the TUI/CLI
     pub fn get_diagnostic_line(&self) -> (String, DiagnosticSeverity) {
         let net = self.net_change();
-        let allocated_kb = self.allocated_bytes / 1024;
-        let freed_kb = self.freed_bytes / 1024;
-        let net_kb = net.abs() / 1024;
+        let allocated_kb = format_bytes(self.allocated_bytes as u64);
+        let freed_kb = format_bytes(self.freed_bytes as u64);
+        let net_kb = format_bytes(net.abs() as u64);
 
         if net > 0 {
             (
                 format!(
-                    "Positive Allocation: +{} KB (Allocated: {} KB | Freed: {} KB) -> Leak Suspected!",
+                    "Positive Allocation: +{} (Allocated: {} | Freed: {} ) -> Leak Suspected!",
                     net_kb, allocated_kb, freed_kb
                 ),
                 DiagnosticSeverity::LeakSuspected,
@@ -29,7 +31,7 @@ impl LeakDelta {
         } else if net < 0 {
             (
                 format!(
-                    "Negative Allocation: -{} KB (Allocated: {} KB | Freed: {} KB) -> Memory Reclaimed.",
+                    "Negative Allocation: -{} (Allocated: {} | Freed: {}) -> Memory Reclaimed.",
                     net_kb, allocated_kb, freed_kb
                 ),
                 DiagnosticSeverity::Reclaimed,
@@ -37,7 +39,7 @@ impl LeakDelta {
         } else {
             (
                 format!(
-                    "Balanced Allocation: 0 KB Change (Allocated: {} KB | Freed: {} KB) -> Healthy.",
+                    "Balanced Allocation: 0 KB Change (Allocated: {} | Freed: {}) -> Healthy.",
                     allocated_kb, freed_kb
                 ),
                 DiagnosticSeverity::Healthy,

--- a/src/core/scan.rs
+++ b/src/core/scan.rs
@@ -7,6 +7,7 @@ use crate::types::RegionProtect::*;
 use crate::types::RegionState::*;
 use crate::types::{HeapBlock, Region};
 use crate::ui::render;
+use crate::utils::formatting::format_bytes;
 use rayon::prelude::*;
 use std::collections::HashSet;
 use std::thread::sleep;
@@ -48,8 +49,8 @@ pub fn scan_with_modes(mode: &String, pid: u32, json: bool, output: Option<Strin
             let free_bytes: usize = free.par_iter().map(|b| b.size).sum();
 
             println!("total blocks : {}", blocks.len());
-            println!("used blocks  : {} ({} KB)", used.len(), used_bytes / 1024);
-            println!("free blocks  : {} ({} KB)", free.len(), free_bytes / 1024);
+            println!("used blocks  : {} ({})", used.len(), format_bytes(used_bytes as u64));
+            println!("free blocks  : {} ({})", free.len(), format_bytes(free_bytes as u64));
 
             let largest_free = blocks
                 .iter()
@@ -70,7 +71,7 @@ pub fn scan_with_modes(mode: &String, pid: u32, json: bool, output: Option<Strin
             let mut sorted = used.clone();
             sorted.sort_by(|a, b| b.size.cmp(&a.size));
             for block in sorted.iter().take(10) {
-                println!("  0x{:x}  {} KB", block.address, block.size / 1024);
+                println!("  0x{:x}  {}", block.address, format_bytes(block.size as u64));
             }
 
             // size distribution
@@ -208,14 +209,14 @@ pub fn scan_with_modes_tui(
 
             output.push(Line::raw(format!("total blocks : {}", blocks.len())));
             output.push(Line::raw(format!(
-                "used blocks  : {} ({} KB)",
+                "used blocks  : {} ({})",
                 used.len(),
-                used_bytes / 1024
+                format_bytes(used_bytes as u64),
             )));
             output.push(Line::raw(format!(
-                "free blocks  : {} ({} KB)",
+                "free blocks  : {} ({})",
                 free.len(),
-                free_bytes / 1024
+                format_bytes(free_bytes as u64)
             )));
             output.push(Line::raw(format!("fragmentation: {:.1}%", frag)));
             output.push(Line::raw("top 10 largest allocations:"));
@@ -223,9 +224,9 @@ pub fn scan_with_modes_tui(
             sorted.sort_by(|a, b| b.size.cmp(&a.size));
             for block in sorted.iter().take(10) {
                 output.push(Line::raw(format!(
-                    "  0x{:x}  {} KB",
+                    "  0x{:x}  {}",
                     block.address,
-                    block.size / 1024
+                    format_bytes(block.size as u64)
                 )));
             }
             output.push(Line::raw("size distribution:"));
@@ -436,11 +437,11 @@ pub fn leak_command(pid: u32, interval: u64) {
     };
     let leak_delta_output = leak_delta.get_diagnostic_line();
     println!("{}", leak_delta_output.0);
-    println!("heap growth: {} KB", growth / 1024);
+    println!("heap growth: {}", format_bytes(growth as u64));
     if growth > 0 {
         println!(
-            "\x1b[31mleak suspected — heap grew by {} KB\x1b[0m",
-            growth / 1024
+            "\x1b[31mleak suspected — heap grew by {}\x1b[0m",
+            format_bytes(growth as u64)
         );
     } else {
         println!("no leak detected");
@@ -463,10 +464,10 @@ pub fn leak_command_tui(pid: u32, interval: u64) -> (Vec<Line<'static>>, LeakDel
     };
     let leak_delta_output = leak_delta.get_diagnostic_line();
     output.push(Line::raw(format!("{}", leak_delta_output.0)));
-    output.push(Line::raw(format!("heap growth: {} KB", growth / 1024)));
+    output.push(Line::raw(format!("heap growth: {}", format_bytes(growth as u64))));
     if growth > 0 {
         output.push(Line::from(Span::styled(
-            format!("leak suspected — heap grew by {} KB", growth / 1024),
+            format!("leak suspected — heap grew by {}", format_bytes(growth as u64)),
             Style::default().fg(Color::Red),
         )));
     } else {
@@ -485,9 +486,9 @@ pub fn leak_m_command(pid: u32, interval: u64, samples: u64) {
 
         print!("sample {} ", i + 1);
         println!(
-            "new allocations: {}  new bytes: {} KB  {}",
+            "new allocations: {}  new bytes: {}  {}",
             results.len(),
-            new_bytes / 1024,
+            format_bytes(new_bytes as u64),
             if results.is_empty() {
                 "ok"
             } else {
@@ -523,9 +524,9 @@ pub fn leak_m_command_tui(pid: u32, interval: u64, samples: u64, tx: Sender<Line
 
         tx.send(Line::from(vec![
             Span::raw(format!(
-                "  new allocations: {}  new bytes: {} KB  ",
+                "  new allocations: {}  new bytes: {}  ",
                 results.len(),
-                new_bytes / 1024,
+                format_bytes(new_bytes as u64),
             )),
             status_span,
         ]))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@ pub mod core;
 pub mod os;
 pub mod types;
 pub mod ui;
+pub mod utils;
 
 pub static VERSION: &str = "v0.3.0";

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use mvis::os;
 use mvis::os::MemoryProvider;
 use mvis::ui::commands::process_is_visible;
 use mvis::ui::tui::tui_main;
+use mvis::utils::formatting::format_bytes;
 use std::env;
 
 fn main() {
@@ -75,10 +76,10 @@ fn run() -> Result<(), String> {
             println!("{}", "-".repeat(50));
             for process in processes.iter().take(20) {
                 println!(
-                    "{:<8} {:<30} {} MB",
+                    "{:<8} {:<30} {}",
                     process.pid().as_u32(),
                     process.name().to_string_lossy(),
-                    process.memory() / 1024 / 1024,
+                    format_bytes(process.memory()),
                 );
             }
         }
@@ -105,7 +106,7 @@ fn run() -> Result<(), String> {
                 println!(
                     "0x{:<16x} {:<10} {:<10} {}",
                     m.base,
-                    format!("{:.1}MB", m.size as f64 / 1024.0 / 1024.0),
+                    format_bytes(m.size as u64),
                     status,
                     m.name,
                 );

--- a/src/ui/commands.rs
+++ b/src/ui/commands.rs
@@ -5,6 +5,7 @@ use crate::os;
 use crate::os::MemoryProvider;
 use crate::types::HeapBlock;
 use ratatui::text::Line;
+use crate::utils::formatting::format_bytes;
 
 pub struct ScanResult {
     pub lines: Vec<Line<'static>>,
@@ -167,10 +168,10 @@ pub fn list_processes(args: Vec<&str>) -> Result<Vec<String>, String> {
     output.push(format!("{}", "-".repeat(50)));
     for process in processes.iter().take(20) {
         output.push(format!(
-            "{:<8} {:<30} {} MB",
+            "{:<8} {:<30} {}",
             process.pid().as_u32(),
             process.name().to_string_lossy(),
-            process.memory() / 1024 / 1024,
+            format_bytes(process.memory()),
         ));
     }
     Ok(output)

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -2,6 +2,7 @@ use crate::types::Region;
 use crate::types::RegionKind::*;
 use crate::types::RegionProtect::*;
 use crate::types::RegionState::*;
+use crate::utils::formatting::format_bytes;
 
 pub fn render_bar(regions: &[Region], labels: &[&str], width: usize) {
     let total: usize = regions.iter().map(|r| r.size).sum();
@@ -78,7 +79,7 @@ pub fn render_verbose(regions: &[Region], labels: &[&str]) {
         println!(
             "{:<18} {:<12} {:<16} {}",
             format!("0x{:x}", region.base),
-            format_size(region.size),
+            format_bytes(region.size as u64),
             labels[i],
             name,
         );
@@ -101,7 +102,7 @@ pub fn render_verbose_tui(regions: &[Region], labels: &[&str]) -> Vec<Line<'stat
         output.push(Line::raw(format!(
             "{:<18} {:<12} {:<16} {}",
             format!("0x{:x}", region.base),
-            format_size(region.size),
+            format_bytes(region.size as u64),
             labels[i],
             name,
         )));
@@ -109,12 +110,3 @@ pub fn render_verbose_tui(regions: &[Region], labels: &[&str]) -> Vec<Line<'stat
     output
 }
 
-pub fn format_size(bytes: usize) -> String {
-    if bytes >= 1024 * 1024 {
-        format!("{:.1}MB", bytes as f64 / (1024.0 * 1024.0))
-    } else if bytes >= 1024 {
-        format!("{:.1}KB", bytes as f64 / 1024.0)
-    } else {
-        format!("{}B", bytes)
-    }
-}

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -9,10 +9,10 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 use ratatui::{DefaultTerminal, Frame};
 
 use super::commands;
-use super::render::format_size;
 use crate::core::delta::{DiagnosticSeverity, LeakDelta};
 use crate::types::{HeapBlock, RegionProtect};
 use crate::ui::commands::ScanResult;
+use crate::utils::formatting::format_bytes;
 
 enum AppEvent {
     DiffResult(Vec<HeapBlock>, ScanResult),
@@ -534,29 +534,29 @@ impl App {
                         // header
                         self.push_line(Line::raw("─".repeat(40)));
                         self.push_line(Line::raw(format!(
-                            "baseline : {} blocks ({} KB)",
+                            "baseline : {} blocks ({})",
                             baseline_blocks.iter().filter(|b| !b.is_free).count(),
-                            baseline_total / 1024,
+                            format_bytes(baseline_total as u64),
                         )));
                         self.push_line(Line::raw(format!(
-                            "current  : {} blocks ({} KB)",
+                            "current  : {} blocks ({})",
                             current.blocks.iter().filter(|b| !b.is_free).count(),
-                            current_total / 1024,
+                            format_bytes(current_total as u64),
                         )));
                         self.push_line(Line::raw("─".repeat(40)));
 
                         // new blocks
                         self.push_line(Line::from(Span::styled(
                             format!(
-                                "+{} new blocks (+{} KB)",
+                                "+{} new blocks (+{})",
                                 new_blocks.len(),
-                                new_bytes / 1024
+                                format_bytes(new_bytes as u64),
                             ),
                             Style::default().fg(Color::Green),
                         )));
                         for block in new_blocks.iter().take(5) {
                             self.push_line(Line::from(Span::styled(
-                                format!("  + 0x{:x}  {} KB", block.address, block.size / 1024),
+                                format!("  + 0x{:x}  {}", block.address, format_bytes(block.size as u64)),
                                 Style::default().fg(Color::Green),
                             )));
                         }
@@ -570,9 +570,9 @@ impl App {
                         // removed blocks
                         self.push_line(Line::from(Span::styled(
                             format!(
-                                "-{} removed (-{} KB)",
+                                "-{} removed (-{})",
                                 removed_blocks.len(),
-                                removed_bytes / 1024
+                                format_bytes(removed_bytes as u64)
                             ),
                             Style::default().fg(Color::Red),
                         )));
@@ -581,7 +581,7 @@ impl App {
                         let net_color = if net > 0 { Color::Red } else { Color::Green };
                         let net_sign = if net > 0 { "+" } else { "" };
                         self.push_line(Line::from(Span::styled(
-                            format!("net growth: {}{} KB", net_sign, net / 1024),
+                            format!("net growth: {}{}", net_sign, format_bytes(net as u64)),
                             Style::default().fg(net_color),
                         )));
 
@@ -1072,7 +1072,7 @@ fn render_heap_metrics(snap: &HeapSnapshot, width: usize) -> Vec<Line<'static>> 
             "░".repeat(bar_w - used_fill),
             Style::default().fg(Color::DarkGray),
         ),
-        Span::raw(format!("  {}", format_size(snap.used_bytes))),
+        Span::raw(format!("  {}", format_bytes(snap.used_bytes as u64))),
     ]));
     lines.push(Line::from(vec![
         Span::raw("Free          "),
@@ -1081,7 +1081,7 @@ fn render_heap_metrics(snap: &HeapSnapshot, width: usize) -> Vec<Line<'static>> 
             Style::default().fg(Color::Blue),
         ),
         Span::styled("░".repeat(used_fill), Style::default().fg(Color::DarkGray)),
-        Span::raw(format!("  {}", format_size(snap.free_bytes))),
+        Span::raw(format!("  {}", format_bytes(snap.free_bytes as u64))),
     ]));
 
     lines.push(Line::raw(""));
@@ -1093,11 +1093,11 @@ fn render_heap_metrics(snap: &HeapSnapshot, width: usize) -> Vec<Line<'static>> 
     lines.push(Line::raw(format!("Free blocks  : {}", snap.free_blocks)));
     lines.push(Line::raw(format!(
         "Largest used : {}",
-        format_size(snap.largest_used)
+        format_bytes(snap.largest_used as u64)
     )));
     lines.push(Line::raw(format!(
         "Largest free : {}",
-        format_size(snap.largest_free)
+        format_bytes(snap.largest_free as u64)
     )));
     lines.push(Line::raw(""));
 
@@ -1194,7 +1194,7 @@ fn render_alloc_table(
                 "{:<5} {:<18} {:<12} {:<8} {:<6} {}",
                 idx,
                 format!("0x{:x}", block.address),
-                format_size(block.size),
+                format_bytes(block.size as u64),
                 note,
                 protect,
                 tag,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod formatting;


### PR DESCRIPTION
Closes #34

Replaced all manual byte formatting across the codebase with the existing `format_bytes` utility from `src/utils/formatting.rs`, as directed by the maintainer.

Files changed:
- `src/main.rs`
- `src/ui/commands.rs`
- `src/ui/tui.rs`
- `src/ui/render.rs` — also removed the now-redundant `format_size` function
- `src/core/scan.rs`
- `src/core/delta.rs`
- `src/utils/mod.rs` — added to expose the utils module