### PR TITLE
fix: retry/fail-fast mvis binary download in smoke-test action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ runs:
             | grep '"tag_name"' | cut -d '"' -f 4)
         fi
         mkdir -p "$RUNNER_TEMP/mvis-bin"
-        curl -sSL \
+        curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
           "https://github.com/SickleFire/m-vis/releases/download/${VERSION}/mvis-linux-x86_64" \
           -o "$RUNNER_TEMP/mvis-bin/mvis"
         chmod +x "$RUNNER_TEMP/mvis-bin/mvis"
@@ -114,7 +114,7 @@ runs:
           ASSET="mvis-macos-x86_64"
         fi
         mkdir -p "$RUNNER_TEMP/mvis-bin"
-        curl -sSL \
+        curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
           "https://github.com/SickleFire/m-vis/releases/download/${VERSION}/${ASSET}" \
           -o "$RUNNER_TEMP/mvis-bin/mvis"
         chmod +x "$RUNNER_TEMP/mvis-bin/mvis"


### PR DESCRIPTION
## Summary
- Fixes #100 — macOS smoke test failure on `dev` (run [30107347653](https://github.com/SickleFire/m-vis/actions/runs/30107347653))
- Root cause: the `curl -sSL` download of the `mvis` binary in `action.yml` (Linux + macOS steps) had no `-f`/`--fail`. When the GitHub release CDN returned a transient `504 Gateway Time-out`, curl wrote the HTML error page to the binary path instead of erroring, `chmod +x` made it "executable", and bash then failed with a confusing `syntax error near unexpected token '<'` instead of a clear download failure.
- Fix: add `-f` and `--retry 3 --retry-delay 2 --retry-all-errors` to both curl download calls, so transient CDN hiccups retry and fail loudly with a clear curl error if they persist, instead of silently corrupting the binary.

## Test plan
- [x] Re-run the `Tests` workflow on this branch/PR and confirm `Action smoke test (macos-latest)` passes
- [x] Confirm `Action smoke test (ubuntu-latest)` still passes (same fix applied there)